### PR TITLE
去掉library中application的声明，否则application的属性不同时将产生冲突，导致编译错误

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,8 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="top.zibin.luban">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
去掉library中application的声明，否则application的属性不同时将产生冲突，导致编译错误