### PR TITLE
recycle bitmap

### DIFF
--- a/library/src/main/java/top/zibin/luban/Luban.java
+++ b/library/src/main/java/top/zibin/luban/Luban.java
@@ -449,12 +449,14 @@ public class Luban {
             options -= 6;
             bitmap.compress(Bitmap.CompressFormat.JPEG, options, stream);
         }
+        bitmap.recycle();
 
         try {
             FileOutputStream fos = new FileOutputStream(filePath);
             fos.write(stream.toByteArray());
             fos.flush();
             fos.close();
+            stream.close();
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
因为在尝试用Luban压缩图片的时候，看到内存占用上涨，压缩完成之后没有释放，最后发现可能是bitmap没有recycle的原因，所以提了这个PR。