### PR TITLE
Added compression switch for each one of all images

### DIFF
--- a/library/src/main/java/top/zibin/luban/CompressionPredicate.java
+++ b/library/src/main/java/top/zibin/luban/CompressionPredicate.java
@@ -1,0 +1,19 @@
+package top.zibin.luban;
+
+/**
+ * Created on 2018/1/3 19:43
+ *
+ * @author andy
+ *
+ * A functional interface (callback) that returns true or false for the given input path should be compressed.
+ */
+
+public interface CompressionPredicate {
+
+    /**
+     * Determine the given input path should be compressed and return a boolean.
+     * @param path input path
+     * @return the boolean result
+     */
+    boolean apply(String path);
+}


### PR DESCRIPTION
Fixed [#194](https://github.com/Curzibn/Luban/issues/194)

Do not compress image file that suffix is ".png" or use other strategy when the developer has been specified.

Sample code

![image](https://user-images.githubusercontent.com/5976556/34551608-93bb8914-f156-11e7-8906-ef9978fe8e29.png)

And

![image](https://user-images.githubusercontent.com/5976556/34551767-ad501cfe-f157-11e7-915c-7a1ac61396c0.png)
